### PR TITLE
3 попытки отправить фото

### DIFF
--- a/custom_components/vk_notify/helpers.py
+++ b/custom_components/vk_notify/helpers.py
@@ -151,15 +151,23 @@ async def async_upload_photo(hass: HomeAssistant, access_token: str, peer_id: in
     else:
         raise HomeAssistantError("Neither URL nor filepath provided for photo upload.")
 
-    async with session.post(upload_url, data=form, timeout=timeout_ctx) as resp:
-        try:
-            upload_result = await resp.json()
-        except Exception:
-            err_text = await resp.text()
-            raise HomeAssistantError(f"Сервер загрузки ВКонтакте недоступен (HTTP {resp.status}). Попробуйте позже.")
+    tries = 1
+    while True:
+        async with session.post(upload_url, data=form, timeout=timeout_ctx) as resp:
+            try:
+                upload_result = await resp.json()
+            except Exception:
+                err_text = await resp.text()
+                raise HomeAssistantError(f"Сервер загрузки ВКонтакте недоступен (HTTP {resp.status}). Попробуйте позже.")
 
-    if "error" in upload_result or not upload_result.get("photo"):
-        raise HomeAssistantError(f"Photo upload error: {upload_result}")
+        if "error" in upload_result or not upload_result.get("photo"):
+            _LOGGER.error(f"Photo upload error:({tries}) {upload_result}")
+            if tries > 2:
+                raise HomeAssistantError(f"Photo upload error:({tries}) {upload_result}")
+            tries += 1
+        else:
+            _LOGGER.warning(f"Photo upload result:({tries}) {upload_result}")
+            break
 
     async with session.post(VK_API_PHOTO_SAVE, data={
         "access_token": access_token, "v": VK_API_VERSION,


### PR DESCRIPTION
Как показала практика - фото загружается только со второй или третьей попытки. Либо на стороне VK что-то глючит, либо внутри session.post файл не добавляется к телу запроса. Добавлял к сессии трассировку параметров запроса - разницы между попытками нет:

```python
...
async def on_request_start(session, context, params):
    logging.getLogger('aiohttp.client').debug(f'Starting request: {params}')

async def async_upload_photo(hass: HomeAssistant, access_token: str, peer_id: int, url: str | None = None, filepath: str | None = None, verify_ssl: bool = True, timeout: int = 60) -> str:
    bypass_ssl = (not verify_ssl) or (url and is_local_url(url))
#    session = async_get_clientsession(hass, verify_ssl=(not bypass_ssl))
    trace_config = aiohttp.TraceConfig()
    trace_config.on_request_start.append(on_request_start)
    session = async_create_clientsession(hass, verify_ssl=(not bypass_ssl),trace_configs=[trace_config])
...
```

При добавлении также дополнительных логов(PR без них) вот типичный кусок логов:
```
2026-09-03 21:19:59.557 DEBUG (MainThread) [aiohttp.client] Starting request: TraceRequestStartParams(method='GET', url=URL('https://api.vk.com/method/photos.getMessagesUploadServer?access_token=XXXXXXXXXXXXXXXXXXXXX&peer_id=2000000002&v=5.199'), headers=<CIMultiDict('User-Agent': 'HomeAssistant/2026.2.2 aiohttp/3.13.3 Python/3.13')>)
2026-09-03 21:19:59.663 WARNING (MainThread) [custom_components.vk_notify.helpers] Upload URL https://pu.vk.com/c906518/ss2309/upload.php?act=do_add&mid=-241071261&aid=-64&gid=0&peer_id=-241071261&rhash=666f23544a806709108479ec7b6ebb55&api=1&method=message&mailphoto=1&server=906518&_origin=https%3A%2F%2Fapi.vk.com&_sig=fe864996c66a86b508d8d56d308d80f8
2026-09-03 21:19:59.665 WARNING (MainThread) [custom_components.vk_notify.helpers] Готов к отправке файла: name=/config/www/dahua_vto_last.jpg, size=50363 bytes
2026-09-03 21:19:59.665 DEBUG (MainThread) [aiohttp.client] Starting request: TraceRequestStartParams(method='POST', url=URL('https://pu.vk.com/c906518/ss2309/upload.php?act=do_add&mid=-241071261&aid=-64&gid=0&peer_id=-241071261&rhash=666f23544a806709108479ec7b6ebb55&api=1&method=message&mailphoto=1&server=906518&_origin=https://api.vk.com&_sig=fe864996c66a86b508d8d56d308d80f8'), headers=<CIMultiDict('User-Agent': 'HomeAssistant/2026.2.2 aiohttp/3.13.3 Python/3.13')>)
2026-09-03 21:20:00.387 ERROR (MainThread) [custom_components.vk_notify.helpers] Photo upload error:(1) {'server': 906518, 'photo': '', 'hash': '06fe97478357d8f1e750f3194b9a20f5'}
2026-09-03 21:20:00.388 DEBUG (MainThread) [aiohttp.client] Starting request: TraceRequestStartParams(method='POST', url=URL('https://pu.vk.com/c906518/ss2309/upload.php?act=do_add&mid=-241071261&aid=-64&gid=0&peer_id=-241071261&rhash=666f23544a806709108479ec7b6ebb55&api=1&method=message&mailphoto=1&server=906518&_origin=https://api.vk.com&_sig=fe864996c66a86b508d8d56d308d80f8'), headers=<CIMultiDict('User-Agent': 'HomeAssistant/2026.2.2 aiohttp/3.13.3 Python/3.13')>)
2026-09-03 21:20:01.130 ERROR (MainThread) [custom_components.vk_notify.helpers] Photo upload error:(2) {'server': 906518, 'photo': '', 'hash': '06fe97478357d8f1e750f3194b9a20f5'}
2026-09-03 21:20:01.131 DEBUG (MainThread) [aiohttp.client] Starting request: TraceRequestStartParams(method='POST', url=URL('https://pu.vk.com/c906518/ss2309/upload.php?act=do_add&mid=-241071261&aid=-64&gid=0&peer_id=-241071261&rhash=666f23544a806709108479ec7b6ebb55&api=1&method=message&mailphoto=1&server=906518&_origin=https://api.vk.com&_sig=fe864996c66a86b508d8d56d308d80f8'), headers=<CIMultiDict('User-Agent': 'HomeAssistant/2026.2.2 aiohttp/3.13.3 Python/3.13')>)
2026-09-03 21:20:01.962 WARNING (MainThread) [custom_components.vk_notify.helpers] Photo upload result:(3) {'server': 906518, 'photo': '[{"markers_restarted":true,"photo":"8877c0cd4e:z","sizes":[],"latitude":0,"longitude":0,"kid":"...","sizes2":[...],"urls":[],"urls2":[...],"peer_id":-241071261}]', 'hash': 'fcd0b4bdbee322f20fd1141c3fd74375'}
2026-09-03 21:20:01.963 DEBUG (MainThread) [aiohttp.client] Starting request: TraceRequestStartParams(method='POST', url=URL('https://api.vk.com/method/photos.saveMessagesPhoto'), headers=<CIMultiDict('User-Agent': 'HomeAssistant/2026.2.2 aiohttp/3.13.3 Python/3.13')>)
```